### PR TITLE
Exchange link cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,27 +225,22 @@
             <div class="col-xs-12 col-sm-6 col-md-7 text-center">
               <div class="info-group last">
                 <h5 localization="buy-exchanges-title">Exchanges</h5>
-                <p localization="buy-exchanges-text">You can acquire Myriad from any of the following popular exchanges. Coming in 2018, you can expect to see Myriad available through more large exchanges as it continues to grow.</p>
+                <!-- Disabling exchange text pending edit and translation
+                  <p localization="buy-exchanges-text">You can acquire Myriad from any of the following popular exchanges. Coming in 2018, you can expect to see Myriad available through more large exchanges as it continues to grow.</p>
+                -->
                 <div class="row">
                   <div class="col-xs-12 col-md-6">
-                    <a href="https://www.litebit.eu/en/buy/myriadcoin" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> Litebit XMY/EUR</a>
-                    <a href="https://bittrex.com/Market/Index?MarketName=BTC-XMY" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> Bittrex XMY/BTC</a>
+                    <a href="https://bittrex.com/Market/Index?MarketName=BTC-XMY" class="btn btn-wisteria" target="_blank">Bittrex</a>
+                    <a href="https://tradesatoshi.com/Exchange/?market=XMY_BTC" class="btn btn-wisteria" target="_blank">TradeSatoshi</a>
+                    <a href="https://cryptofacil.com/trading-view/27/BTC-XMY" class="btn btn-wisteria" target="_blank">CryptoFacil</a>
                   </div>
 
                   <div class="col-xs-12 col-md-6">
-                    <a href="https://www.gonetcoins.com/" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> Netcoins XMY/<span localization="local-cash">local cash</span></a>
-                    <a href="https://cryptofacil.com/trading-view/27/BTC-XMY" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> CryptoFacil XMY/BTC,LTC,DOGE</a>
+                    <a href="https://www.litebit.eu/en/buy/myriadcoin" class="btn btn-wisteria" target="_blank">Litebit</a>
+                    <a href="https://www.bitladon.com/myriad" class="btn btn-wisteria" target="_blank">BITLADON</a>
+                    <a href="https://www.gonetcoins.com/" class="btn btn-wisteria" target="_blank">Netcoins (<span localization="local-cash">local cash</span>)</a>
+                    <a href="https://www.localbitcoincash.org/" class="btn btn-wisteria" target="_blank">LocalBitcoinCash (<span localization="live-coin-swaps">live swaps</span>)</a>
                   </div>
-                  
-                  <div class="col-xs-12 col-md-6">
-                    <a href="https://tradesatoshi.com/Exchange/?market=XMY_BTC" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> TradeSatoshi XMY/BTC,LTC,DOGE</a>
-                    <a href="https://www.bitladon.com/myriad" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> BITLADON XMY/EUR</a>
-                  </div> 
-                
-                  <div class="col-xs-12 col-md-6">
-                    <a href="https://www.localbitcoincash.org/" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> LocalBitcoinCash XMY/* (<span localization="live-coin-swaps">live swaps</span>)</a>
-                    <a href="https://www.finexbox.com/market/pair/XMY-BTC.html" class="btn btn-wisteria" target="_blank"><i class="ion-locked"></i> Finexbox XMY/BTC</a>
-                  </div> 
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Removed "locked" (secure) icon from buttons.           
Removed verbose info from buttons.        
Removed link to one exchange: This exchange has always used obviously bad data in its API and on its website, making them useless for exchanging Myriadcoin.