### PR TITLE
cryptap.us -> cryptapus.org and paperwallet site

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
             <div class="col-xs-12 col-sm-4 text-center">
               <div class="info-group last">
                 <h5 class="color-purple-mountains-majesty" localization="why-myriad-distribution-title">Distribution</h5>
-                <p localization="why-myriad-distribution-text">Myriad was released to the wild on February 23, 2014 at 18:30 UTC. The <a href="http://insight-myr.cryptap.us/block/cb41589c918fba1beccca8bc6b34b2b928b4f9888595d7664afd6ec60a576291" target="_blank">first mined block</a> came 4 minutes later, thus establishing that there was no premine.<br /><br />The initial reward was 1,000 MYR, halving every 967,680 blocks (approximately 48 weeks). Total supply is approximately 2 billion MYR. Target block time is 60 seconds, or 300 seconds per algorithm.</p>
+                <p localization="why-myriad-distribution-text">Myriad was released to the wild on February 23, 2014 at 18:30 UTC. The <a href="https://xmy-blockbook1.coinid.org/block/cb41589c918fba1beccca8bc6b34b2b928b4f9888595d7664afd6ec60a576291" target="_blank">first mined block</a> came 4 minutes later, thus establishing that there was no premine.<br /><br />The initial reward was 1,000 MYR, halving every 967,680 blocks (approximately 48 weeks). Total supply is approximately 2 billion MYR. Target block time is 60 seconds, or 300 seconds per algorithm.</p>
               </div>
             </div>
           </div>
@@ -272,11 +272,6 @@
 	<a href=""><img src="images/star vape.jpg" style="width:100%; height:100%" ></a>
 <p> &nbsp </p>			   
 <p> &nbsp </p>			   
- <b>  Coinbomb Game</b> :
-<p> &nbsp </p>			   
-	<a href="https://cryptap.us/myr/dice/#coinbomb"><img src="images/trader7.jpg" style="width:100%; height:100%" ></a>
-<p> &nbsp </p>			   
-	<p> &nbsp </p>			   
 	 <b>  Web Wallet</b> :
 <p> &nbsp </p>			   
 	<a href="https://jswallet.github.io/"><img src="images/trader 12.jpg" style="width:100%; height:100%" ></a>
@@ -473,12 +468,12 @@
 
                 <div class="platform">
                       <h6 localization="wallets-other-brain">Brain Wallet</h6>
-                  <a href="https://cryptap.us/myr/brainwallet" class="btn btn-shark" target="_blank"><i class="ion-happy hidden-sm"></i> <span localization="wallets-other-download">Download</span></a>
+                  <a href="https://cryptapus.org/myr/brainwallet" class="btn btn-shark" target="_blank"><i class="ion-happy hidden-sm"></i> <span localization="wallets-other-download">Download</span></a>
                 </div>
 
                 <div class="platform">
                     <h6 localization="wallets-other-paper">Paper Wallet</h6>
-                  <a href="https://cryptap.us/myr/paperwallet.html" class="btn btn-shark" target="_blank"><i class="ion-document-text hidden-sm"></i> <span localization="wallets-other-download">Download</span></a>
+                  <a href="https://myriadcoinpaperwallet.github.io" class="btn btn-shark" target="_blank"><i class="ion-document-text hidden-sm"></i> <span localization="wallets-other-download">Download</span></a>
                 </div>
               </div>
             </div>
@@ -785,10 +780,10 @@
             <div class="col-xs-12 col-sm-4">
               <div class="info-group text-center last">
                 <h5 class="color-smalt-blue" localization="resources-other-title">Other</h5>
-                <a href="https://cryptap.us/myr/faucet/" class="btn btn-wisteria" target="_blank" localization="resources-faucet-button">Faucet</a>
+                <a href="https://cryptapus.org/myr/faucet/" class="btn btn-wisteria" target="_blank" localization="resources-faucet-button">Faucet</a>
                 <a href="http://coinmarketcap.com/currencies/myriadcoin/" class="btn btn-wisteria" target="_blank" localization="resources-coinmarketcap-button">Coinmarketcap</a>
                 <a href="https://www.reddit.com/r/myriadcoin/comments/47pww5/testnet_nodes_and_faucet/" class="btn btn-wisteria" target="_blank" localization="resources-testnet-information-button">Testnet Information</a>
-                <a href="https://cryptap.us/myr/" class="btn btn-wisteria" target="_blank" localization="resources-cryptapus-myriad-page-button">Cryptap.us Myriad page</a>
+                <a href="https://cryptapus.org/myr/" class="btn btn-wisteria" target="_blank" localization="resources-cryptapus-myriad-page-button">Cryptap.us Myriad page</a>
                 <a href="https://www.reddit.com/r/myrbot/wiki/index" class="btn btn-wisteria" target="_blank" localization="reddit-irc-myrbot-information-button">Reddit/IRC myrbot information</a>
                 <a href="https://wordpress.org/plugins/nomiddleman-crypto-payments-for-woocommerce" class="btn btn-wisteria" target="_blank" localization="Woocommerce-Payment-Plugin-button">Woocommerce Payment Plugin</a>
               </div>


### PR DESCRIPTION
Updated links for cryptapus.org, paperwallet site now on github, removed a dead link.